### PR TITLE
Added module-info for JDK9+ module support. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/.idea/*
+jaxen.iml
+/target
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -7,4 +7,39 @@ DOM, XOM, dom4j, and JDOM. It is also possible to write
 adapters that treat non-XML trees such as compiled Java byte code
 or Java beans as XML, thus enabling you to query these trees with XPath too.
 
-The current version is *1.1.6*.
+The current version is *1.2.0*
+
+Version *1.2.x* is compiled with maven-toolchains-plugin to retain compatibility with Java 5..
+
+To compile from src you will need a toolchains.xml file in your local maven root.
+
+i.e. ~/.m2/toolchains.xml
+
+```
+<toolchains>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>8</version>
+      <vendor>oracle</vendor>
+      <id>for_jaxen</id>
+    </provides>
+    <configuration>
+      <jdkHome>/Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home</jdkHome>
+    </configuration>
+  </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>10</version>
+      <vendor>oracle</vendor>
+      <id>for_jaxen_10</id>
+    </provides>
+    <configuration>
+      <jdkHome>/Library/Java/JavaVirtualMachines/jdk-10.0.2.jdk/Contents/Home</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>
+```
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -221,14 +221,37 @@
     <testSourceDirectory>src/java/test</testSourceDirectory>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <version>1.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>toolchain</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <toolchains>
+            <jdk>
+              <version>[8,10)</version>
+            </jdk>
+          </toolchains>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <executions>
           <execution>
             <id>default-compile</id>
             <configuration>
-              <!-- compile everything except module-info to Level 6 -->
-              <release>6</release>
+              <!-- compile everything except module-info to Level 5 -->
+              <jdkToolchain>
+                <version>8</version>
+              </jdkToolchain>
+              <source>1.5</source>
+              <target>1.5</target>
               <excludes>module-info.java</excludes>
             </configuration>
           </execution>
@@ -239,6 +262,9 @@
             </goals>
             <!-- recompile just the module-info.java for 9+ -->
             <configuration>
+              <jdkToolchain>
+                <version>10</version>
+              </jdkToolchain>
               <release>9</release>
               <includes>module-info.java</includes>
             </configuration>
@@ -248,7 +274,6 @@
           <debug>true</debug>
           <optimize>true</optimize>
           <showDeprecation>true</showDeprecation>
-          <release>6</release>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>jaxen</artifactId>
   <packaging>bundle</packaging>
   <name>jaxen</name>
-  <version>1.1.6</version>
+  <version>1.2.0</version>
   <description>Jaxen is a universal Java XPath engine.</description>
   <url>http://www.cafeconleche.org/jaxen</url>
   <licenses>
@@ -222,20 +222,40 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.5.1</version>
+        <version>3.8.0</version>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <!-- compile everything except module-info to Level 6 -->
+              <release>6</release>
+              <excludes>module-info.java</excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>base-compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <!-- recompile just the module-info.java for 9+ -->
+            <configuration>
+              <release>9</release>
+              <includes>module-info.java</includes>
+            </configuration>
+          </execution>
+        </executions>
         <configuration>
           <debug>true</debug>
           <optimize>true</optimize>
           <showDeprecation>true</showDeprecation>
-          <source>1.3</source>
-          <target>1.2</target>
+          <release>6</release>
         </configuration>
       </plugin>
 
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+        <version>3.5.1</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>
@@ -245,7 +265,8 @@
             <Export-Package>org.jaxen.*;version=${project.version}</Export-Package>
             <Include-Resource>
               org/w3c/dom/UserDataHandler.class=target/classes/org/w3c/dom/UserDataHandler.class,
-              META-INF/LICENSE.txt=LICENSE.txt
+              META-INF/LICENSE.txt=LICENSE.txt,
+              module-info.class=target/classes/module-info.class
             </Include-Resource>
             <Import-Package>
               org.w3c.dom;resolution:=optional,
@@ -330,9 +351,9 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>jdom</groupId>
+      <groupId>org.jdom</groupId>
       <artifactId>jdom</artifactId>
-      <version>1.0</version>
+      <version>1.1.3</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/java/main/module-info.java
+++ b/src/java/main/module-info.java
@@ -1,0 +1,22 @@
+module jaxen {
+  requires java.xml;
+  requires jdom;
+  requires dom4j;
+  requires xom;
+  exports org.jaxen;
+  exports org.jaxen.dom;
+  exports org.jaxen.dom4j;
+  exports org.jaxen.expr;
+  exports org.jaxen.expr.iter;
+  exports org.jaxen.function;
+  exports org.jaxen.function.ext;
+  exports org.jaxen.function.xslt;
+  exports org.jaxen.javabean;
+  exports org.jaxen.jdom;
+  exports org.jaxen.pattern;
+  exports org.jaxen.saxpath;
+  exports org.jaxen.saxpath.base;
+  exports org.jaxen.saxpath.helpers;
+  exports org.jaxen.util;
+  exports org.jaxen.xom;
+}


### PR DESCRIPTION
Added module-info for JDK9+ module support. 
The org.w3c.dom package is still included but no longer exported.

Changes to pom.xml, were necessary to split the compilation and minimum Java version stays at 5

Resolves https://github.com/jaxen-xpath/jaxen/issues/12