### PR TITLE
Fix xpath with default ns

### DIFF
--- a/core/src/java/main/org/jaxen/expr/DefaultNameStep.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultNameStep.java
@@ -165,12 +165,9 @@ public class DefaultNameStep extends DefaultStep implements NameStep {
             Object contextNode = contextNodeSet.get(0);
             if (namedAccess) {
                 // get the iterator over the nodes and check it
-                String uri = null;
-                if (hasPrefix) {
-                    uri = support.translateNamespacePrefixToUri(prefix);
-                    if (uri == null) {
-                        throw new UnresolvableException("XPath expression uses unbound namespace prefix " + prefix);
-                    }
+                String uri = support.translateNamespacePrefixToUri(prefix);
+                if (hasPrefix && uri == null) {
+                    throw new UnresolvableException("XPath expression uses unbound namespace prefix " + prefix);
                 }
                 Iterator axisNodeIter = iterableAxis.namedAccessIterator(
                                 contextNode, support, localName, prefix, uri);

--- a/dom4j-navigator/src/java/test/org/jaxen/test/DOM4JXPathTest.java
+++ b/dom4j-navigator/src/java/test/org/jaxen/test/DOM4JXPathTest.java
@@ -51,8 +51,10 @@ package org.jaxen.test;
 import junit.framework.TestCase;
 
 import java.io.StringReader;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.dom4j.Attribute;
 import org.dom4j.Document;
@@ -64,6 +66,7 @@ import org.dom4j.tree.DefaultAttribute;
 import org.dom4j.tree.DefaultDocument;
 import org.dom4j.tree.DefaultElement;
 import org.jaxen.JaxenException;
+import org.jaxen.SimpleNamespaceContext;
 import org.jaxen.XPath;
 import org.jaxen.XPathSyntaxException;
 import org.jaxen.dom4j.Dom4jXPath;
@@ -148,6 +151,23 @@ public class DOM4JXPathTest extends TestCase
         List results = xpath.selectNodes( doc );
         assertEquals( 0, results.size() );
 
+    }
+
+    public void testDefaultNamespace() throws DocumentException, JaxenException
+    {
+        String document = "<?xml version=\"1.0\"?>\n<a xmlns=\"uri:1\"><b>c</b></a>";
+        SAXReader reader = new SAXReader();
+        Document doc = reader.read(new StringReader(document));
+
+        XPath xpath = new Dom4jXPath("/a/b");
+
+        // This namespace context simulates dom4j's behaviour, where the current context element resolves the namespace prefix.
+        Map namespaces = new HashMap();
+        namespaces.put("", "uri:1");
+        xpath.setNamespaceContext(new SimpleNamespaceContext(namespaces));
+
+        List results = xpath.selectNodes(doc);
+        assertEquals(1, results.size());
     }
     
     public void testNamespaceNodesAreInherited() throws JaxenException


### PR DESCRIPTION
In dom4j currently it is possible to select /a but not /a/b for the given document:
`<?xml version="1.0"?>
<a xmlns="uri:1">
    <b>c</b>
</a>`

There is also a bug in dom4j, but the change in DefaultNameStep is necessary to make it work at all.