### PR TITLE
stop Javadoc from breaking build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.felix.version>2.3.7</project.felix.version>
+    <project.javadoc.version>3.4.1</project.javadoc.version>
     <maven.compiler.source>1.5</maven.compiler.source>
     <maven.compiler.target>1.5</maven.compiler.target>
   </properties>
@@ -269,7 +270,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.4.1</version>
+        <version>${project.javadoc.version}</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -341,7 +342,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.4.1</version>
+        <version>${project.javadoc.version}</version>
         <configuration>
           <doclint>none</doclint>
           <excludePackageNames>org.jaxen.saxpath.base,org.jaxen.saxpath.helpers,org.jaxen.pattern,org.jaxen.jdom,org.jaxen.xom,org.jaxen.dom4j</excludePackageNames>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.felix.version>2.3.7</project.felix.version>
-    <project.javadoc.version>3.4.1</project.javadoc.version>
     <maven.compiler.source>1.5</maven.compiler.source>
     <maven.compiler.target>1.5</maven.compiler.target>
   </properties>
@@ -197,8 +196,9 @@
 
   <organization>
     <name>The Jaxen Project</name>
-    <url>http://www.cafeconleche.org/jaxen</url>
+    <url>https://www.cafeconleche.org/jaxen</url>
   </organization>
+
 
   <build>
     <sourceDirectory>src/java/main</sourceDirectory>
@@ -267,8 +267,9 @@
         <version>2.3.1</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${project.javadoc.version}</version>
+        <version>3.4.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -278,8 +279,8 @@
           </execution>
         </executions>
         <configuration>
-          <failOnError>false</failOnError>
-          <excludePackageNames>org.jaxen.saxpath.base,org.jaxen.saxpath.helpers</excludePackageNames>
+          <doclint>none</doclint>
+          <excludePackageNames>org.jaxen.saxpath.base,org.jaxen.saxpath.helpers,org.jaxen.pattern,org.jaxen.jdom,org.jaxen.xom,org.jaxen.dom4j</excludePackageNames>
           <links>
             <link>https://docs.oracle.com/javase/6/docs/api/</link>
           </links>
@@ -338,10 +339,24 @@
         <version>2.9.1</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${project.javadoc.version}</version>
+        <version>3.4.1</version>
         <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
+          <doclint>none</doclint>
+          <excludePackageNames>org.jaxen.saxpath.base,org.jaxen.saxpath.helpers,org.jaxen.pattern,org.jaxen.jdom,org.jaxen.xom,org.jaxen.dom4j</excludePackageNames>
+          <links>
+            <link>https://docs.oracle.com/javase/6/docs/api/</link>
+          </links>
+          <docencoding>UTF-8</docencoding>
+          <tags>
+            <tag>
+              <head>To Do:</head>
+              <name>todo</name>
+              <placement>Xa</placement>
+            </tag>
+          </tags>
+          <docencoding>UTF-8</docencoding>
         </configuration>
       </plugin>
       <plugin>
@@ -418,7 +433,7 @@
           </plugin>
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
-      <artifactId>nexus-staging-maven-plugin</artifactId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
             <version>1.6.6</version>
             <extensions>true</extensions>
             <configuration>


### PR DESCRIPTION
Turns out one has to configure both build and reporting. Also the syntax changed when the plugin was updated. 