### PR TITLE
use Posix tar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.4</version>
+        <version>3.4.2</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -256,6 +256,7 @@
           </execution>
         </executions>
         <configuration>
+          <tarLongFileMode>posix</tarLongFileMode>
           <descriptorRefs>
             <descriptorRef>project</descriptorRef>
             <descriptorRef>src</descriptorRef>


### PR DESCRIPTION
fixes #146 

Gnu tar supports Posix archives so this is probably more portable