### PR TITLE
remove duplicated condition from PatternParser convertStep

### DIFF
--- a/core/src/java/main/org/jaxen/pattern/PatternParser.java
+++ b/core/src/java/main/org/jaxen/pattern/PatternParser.java
@@ -213,10 +213,6 @@ public class PatternParser
         {
             path.setNodeTest( TextNodeTest.SINGLETON );
         }
-        else if ( step instanceof DefaultCommentNodeStep )
-        {
-            path.setNodeTest( NodeTypeTest.COMMENT_TEST );
-        }
         else if ( step instanceof DefaultNameStep )
         {
             DefaultNameStep nameStep = (DefaultNameStep) step;


### PR DESCRIPTION
The condition `step instanceof DefaultCommentNodeStep` is already handled in line 204. So this path could never be reached.