### PR TITLE
Simplify assertions

### DIFF
--- a/core/src/java/test/org/jaxen/test/BaseXPathTest.java
+++ b/core/src/java/test/org/jaxen/test/BaseXPathTest.java
@@ -820,7 +820,7 @@ public class BaseXPathTest extends TestCase {
         org.w3c.dom.Element a = doc.createElementNS("", "a");
         doc.appendChild(a);
         List<?> result = xpath.selectNodes(doc);
-        assertTrue(! xpath.booleanValueOf(result));
+        assertFalse(xpath.booleanValueOf(result));
         
     } 
     
@@ -1090,8 +1090,8 @@ public class BaseXPathTest extends TestCase {
         XPath xpath = new DOMXPath("/*/*/namespace::node() | //attribute::* ");
         List<?> result = xpath.selectNodes(doc);
         assertEquals(3, result.size());
-        assertTrue(((org.w3c.dom.Node) result.get(0)).getNodeType() == Node.ATTRIBUTE_NODE);
-        assertTrue(((org.w3c.dom.Node) result.get(1)).getNodeType() == Pattern.NAMESPACE_NODE);
+        assertEquals(Node.ATTRIBUTE_NODE, ((Node) result.get(0)).getNodeType());
+        assertEquals(Pattern.NAMESPACE_NODE, ((Node) result.get(1)).getNodeType());
    
     }
 

--- a/core/src/java/test/org/jaxen/test/ContextTest.java
+++ b/core/src/java/test/org/jaxen/test/ContextTest.java
@@ -132,8 +132,8 @@ public class ContextTest extends TestCase
 
         assertEquals(2, dupe.getPosition());
         assertEquals(4, dupe.getSize());
-        
-        assertTrue( original != dupe );
+
+        assertNotSame(original, dupe);
 
         List<?> dupeNodeSet = dupe.getNodeSet();
 

--- a/core/src/java/test/org/jaxen/test/DOM4JXPathTest.java
+++ b/core/src/java/test/org/jaxen/test/DOM4JXPathTest.java
@@ -105,7 +105,7 @@ public class DOM4JXPathTest extends TestCase
                       ((Element)iter.next()).getName() );
         assertEquals( "baz",
                       ((Element)iter.next()).getName() );
-        assertTrue( ! iter.hasNext() );
+        assertFalse(iter.hasNext());
 
     }
     
@@ -118,7 +118,7 @@ public class DOM4JXPathTest extends TestCase
         assertTrue( "Xpath worked: " + xpath, answer );
         xpath = new Dom4jXPath( "'a' = 'b'" );
         answer = xpath.booleanValueOf( doc );
-        assertTrue( "XPath should return false: " + xpath, ! answer );
+        assertFalse("XPath should return false: " + xpath, answer);
     }
     
     public void testJaxen20AttributeNamespaceNodes() throws JaxenException

--- a/core/src/java/test/org/jaxen/test/DOMXPathTest.java
+++ b/core/src/java/test/org/jaxen/test/DOMXPathTest.java
@@ -338,7 +338,7 @@ public class DOMXPathTest extends TestCase
         assertEquals( "baz",
                       ((Element)iter.next()).getLocalName() );
 
-        assertTrue( ! iter.hasNext() );
+        assertFalse(iter.hasNext());
 
     }
     

--- a/core/src/java/test/org/jaxen/test/JDOMXPathTest.java
+++ b/core/src/java/test/org/jaxen/test/JDOMXPathTest.java
@@ -106,7 +106,7 @@ public class JDOMXPathTest extends TestCase
         assertEquals( "baz",
                       ((Element)iter.next()).getName() );
 
-        assertTrue( ! iter.hasNext() );
+        assertFalse(iter.hasNext());
     }
     
     

--- a/core/src/java/test/org/jaxen/test/XOMXPathTest.java
+++ b/core/src/java/test/org/jaxen/test/XOMXPathTest.java
@@ -101,6 +101,6 @@ public class XOMXPathTest extends TestCase
         assertEquals( "baz",
                       ((Element)iter.next()).getLocalName() );
 
-        assertTrue( ! iter.hasNext() );
+        assertFalse(iter.hasNext());
     }
 }


### PR DESCRIPTION
Instead of inverting an boolean `assertFalse` can be used.
For checking if to Object are not the same `assertNotSame`.
And for comparing to values `assertEquals` should be used.