### PR TITLE
refactor DefaultFunctionCallExpr

### DIFF
--- a/core/src/java/main/org/jaxen/expr/DefaultFunctionCallExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultFunctionCallExpr.java
@@ -60,15 +60,15 @@ class DefaultFunctionCallExpr extends DefaultExpr implements FunctionCallExpr
 {
 
     private static final long serialVersionUID = -4747789292572193708L;
-    private String prefix;
-    private String functionName;
-    private List parameters;
+    private final String prefix;
+    private final String functionName;
+    private List<Expr> parameters;
 
     public DefaultFunctionCallExpr(String prefix, String functionName)
     {
         this.prefix = prefix;
         this.functionName = functionName;
-        this.parameters = new ArrayList();
+        this.parameters = new ArrayList<Expr>();
     }
 
     public void addParameter(Expr parameter)
@@ -77,7 +77,7 @@ class DefaultFunctionCallExpr extends DefaultExpr implements FunctionCallExpr
     }
 
 
-    public List getParameters()
+    public List<Expr> getParameters()
     {
         return this.parameters;
     }
@@ -108,10 +108,10 @@ class DefaultFunctionCallExpr extends DefaultExpr implements FunctionCallExpr
         builder.append(getFunctionName());
         builder.append("(");
 
-        Iterator paramIter = getParameters().iterator();
+        Iterator<Expr> paramIter = getParameters().iterator();
 
         while (paramIter.hasNext()) {
-            Expr eachParam = (Expr) paramIter.next();
+            Expr eachParam = paramIter.next();
 
             builder.append(eachParam.getText());
 
@@ -126,17 +126,15 @@ class DefaultFunctionCallExpr extends DefaultExpr implements FunctionCallExpr
         return builder.toString();
     }
 
+    @Override
     public Expr simplify()
     {
-        List paramExprs = getParameters();
+        List<Expr> paramExprs = getParameters();
         int paramSize = paramExprs.size();
 
-        List newParams = new ArrayList(paramSize);
+        List<Expr> newParams = new ArrayList<Expr>(paramSize);
 
-        for (int i = 0; i < paramSize; ++i)
-        {
-            Expr eachParam = (Expr) paramExprs.get(i);
-
+        for (Expr eachParam : paramExprs) {
             newParams.add(eachParam.simplify());
         }
 
@@ -170,25 +168,20 @@ class DefaultFunctionCallExpr extends DefaultExpr implements FunctionCallExpr
         Function func = context.getFunction(namespaceURI,
                 prefix,
                 getFunctionName());
-        List paramValues = evaluateParams(context);
+        List<Object> paramValues = evaluateParams(context);
 
         return func.call(context, paramValues);
     }
 
-    public List evaluateParams(Context context) throws JaxenException
+    public List<Object> evaluateParams(Context context) throws JaxenException
     {
-        List paramExprs = getParameters();
+        List<Expr> paramExprs = getParameters();
         int paramSize = paramExprs.size();
 
-        List paramValues = new ArrayList(paramSize);
+        List<Object> paramValues = new ArrayList<Object>(paramSize);
 
-        for (int i = 0; i < paramSize; ++i)
-        {
-            Expr eachParam = (Expr) paramExprs.get(i);
-
-            Object eachValue = eachParam.evaluate(context);
-
-            paramValues.add(eachValue);
+        for (Expr eachParam : paramExprs) {
+            paramValues.add(eachParam.evaluate(context));
         }
         return paramValues;
     }


### PR DESCRIPTION
I made the fields `prefix` and `functionName` final.
Gentrified all lists and replaced the for loop by the foreach loop (available size Java 5).

The foreach loop is easier to read and faster, compared to the normal for loop.