### PR TITLE
deprecate own implementation of SingletonList

### DIFF
--- a/core/src/java/main/org/jaxen/BaseXPath.java
+++ b/core/src/java/main/org/jaxen/BaseXPath.java
@@ -49,6 +49,7 @@
 package org.jaxen;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 
 import org.jaxen.expr.Expr;
@@ -59,7 +60,6 @@ import org.jaxen.function.StringFunction;
 import org.jaxen.saxpath.SAXPathException;
 import org.jaxen.saxpath.XPathReader;
 import org.jaxen.saxpath.helpers.XPathReaderFactory;
-import org.jaxen.util.SingletonList;
 
 /** Base functionality for all concrete, implementation-specific XPaths.
  *
@@ -568,7 +568,7 @@ public class BaseXPath implements XPath, Serializable
         }
         else
         {
-            List list = new SingletonList(node);
+            List list = Collections.singletonList(node);
             fullContext.setNodeSet( list );
         }
 

--- a/core/src/java/main/org/jaxen/expr/DefaultAbsoluteLocationPath.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultAbsoluteLocationPath.java
@@ -54,7 +54,6 @@ import org.jaxen.Context;
 import org.jaxen.ContextSupport;
 import org.jaxen.JaxenException;
 import org.jaxen.Navigator;
-import org.jaxen.util.SingletonList;
 
 class DefaultAbsoluteLocationPath extends DefaultLocationPath 
 {
@@ -100,7 +99,7 @@ class DefaultAbsoluteLocationPath extends DefaultLocationPath
             return Collections.EMPTY_LIST;
         }
 
-        List list = new SingletonList(docNode);
+        List list = Collections.singletonList(docNode);
 
         absContext.setNodeSet( list );
 

--- a/core/src/java/main/org/jaxen/expr/DefaultExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultExpr.java
@@ -49,11 +49,11 @@
 
 package org.jaxen.expr;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
 import org.jaxen.util.SingleObjectIterator;
-import org.jaxen.util.SingletonList;
 
 abstract class DefaultExpr implements Expr
 {
@@ -84,6 +84,6 @@ abstract class DefaultExpr implements Expr
             return (List) obj;
         }
 
-        return new SingletonList(obj);
+        return Collections.singletonList(obj);
     }
 }

--- a/core/src/java/main/org/jaxen/pattern/LocationPathPattern.java
+++ b/core/src/java/main/org/jaxen/pattern/LocationPathPattern.java
@@ -48,6 +48,7 @@
 package org.jaxen.pattern;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -55,7 +56,6 @@ import org.jaxen.Context;
 import org.jaxen.JaxenException;
 import org.jaxen.Navigator;
 import org.jaxen.expr.FilterExpr;
-import org.jaxen.util.SingletonList;
 
 /** <p><code>LocationPathPattern</code> matches any node using a
   * location path such as A/B/C.
@@ -212,7 +212,7 @@ public class LocationPathPattern extends Pattern {
         
         if (filters != null) 
         {
-            List list = new SingletonList(node);
+            List list = Collections.singletonList(node);
 
             context.setNodeSet( list );
             

--- a/core/src/java/main/org/jaxen/util/SingletonList.java
+++ b/core/src/java/main/org/jaxen/util/SingletonList.java
@@ -59,8 +59,9 @@ import java.util.AbstractList;
  * 
  * @version 1.2b12
  * @author Attila Szegedi
- * 
+ * @deprecated use java.util.Collections.singletonList() instead.
  */
+@Deprecated
 public class SingletonList extends AbstractList {
     
     private final Object element;

--- a/core/src/java/test/org/jaxen/test/SingletonListTest.java
+++ b/core/src/java/test/org/jaxen/test/SingletonListTest.java
@@ -51,6 +51,7 @@ import org.jaxen.util.SingletonList;
 
 import junit.framework.TestCase;
 
+@Deprecated
 public class SingletonListTest extends TestCase {
 
     public void testIndexOutOfBoundsException() {


### PR DESCRIPTION
Java offers since 1.3 an standard implementation of `SingletonList`. The standard implementation has support for generics and offers the same immutability as the own implementation. So I deprecate this one and replaced all calls except the test with the standard implementation.