### PR TITLE
remove public modifier from interfaces

### DIFF
--- a/core/src/java/main/org/jaxen/VariableContext.java
+++ b/core/src/java/main/org/jaxen/VariableContext.java
@@ -107,7 +107,7 @@ public interface VariableContext
      *  @return  the variable's value (which can be <code>null</code>)
      *  @throws UnresolvableException  when the variable cannot be resolved
      */
-    public Object getVariableValue( String namespaceURI,
+    Object getVariableValue( String namespaceURI,
                                     String prefix,
                                     String localName )
         throws UnresolvableException;

--- a/core/src/java/main/org/jaxen/expr/FilterExpr.java
+++ b/core/src/java/main/org/jaxen/expr/FilterExpr.java
@@ -75,10 +75,10 @@ public interface FilterExpr extends Expr, Predicated
      * 
      * @return true if a node matches; false if no node matches
      */
-    public boolean asBoolean(Context context) throws JaxenException;
+    boolean asBoolean(Context context) throws JaxenException;
     
     /** 
      * @return the underlying filter expression
      */
-    public Expr getExpr();
+    Expr getExpr();
 }

--- a/core/src/java/main/org/jaxen/expr/FunctionCallExpr.java
+++ b/core/src/java/main/org/jaxen/expr/FunctionCallExpr.java
@@ -66,21 +66,21 @@ public interface FunctionCallExpr extends Expr
      * 
      * @return the namespace prefix of the function
      */
-    public String getPrefix();
+    String getPrefix();
     
     /**
      * Returns the local name of the function. 
      * 
      * @return the local name of the function
      */
-    public String getFunctionName();
+    String getFunctionName();
     
     /**
      * Add the next argument to the function. 
      * 
      * @param parameter a function argument 
      */
-    public void addParameter(Expr parameter);
+    void addParameter(Expr parameter);
     
     /**
      * Returns the the ordered list of function arguments.
@@ -88,6 +88,6 @@ public interface FunctionCallExpr extends Expr
      * 
      * @return the ordered list of function arguments
      */
-    public List getParameters();
+    List getParameters();
     
 }

--- a/core/src/java/main/org/jaxen/expr/LiteralExpr.java
+++ b/core/src/java/main/org/jaxen/expr/LiteralExpr.java
@@ -66,5 +66,5 @@ public interface LiteralExpr extends Expr
      * 
      * @return the contents of the string literal
      */
-    public String getLiteral();
+    String getLiteral();
 }

--- a/core/src/java/main/org/jaxen/expr/NameStep.java
+++ b/core/src/java/main/org/jaxen/expr/NameStep.java
@@ -65,11 +65,11 @@ public interface NameStep extends Step
      * 
      * @return the namespace prefix of the natched node
      */
-    public String getPrefix();
+    String getPrefix();
     
     /**
      * Returns the local name of the matched node 
      * 
      * @return the local name of the test
      */
-    public String getLocalName();}
+    String getLocalName();}

--- a/core/src/java/main/org/jaxen/expr/NumberExpr.java
+++ b/core/src/java/main/org/jaxen/expr/NumberExpr.java
@@ -64,5 +64,5 @@ public interface NumberExpr extends Expr
      * 
      * @return a <code>java.lang.Double</code> representing the number
      */
-    public Number getNumber();
+    Number getNumber();
 }

--- a/core/src/java/main/org/jaxen/expr/ProcessingInstructionNodeStep.java
+++ b/core/src/java/main/org/jaxen/expr/ProcessingInstructionNodeStep.java
@@ -57,5 +57,5 @@ public interface ProcessingInstructionNodeStep extends Step
      * 
      * @return the target of the processing instruction
      */
-    public String getName();
+    String getName();
 }

--- a/core/src/java/main/org/jaxen/expr/Step.java
+++ b/core/src/java/main/org/jaxen/expr/Step.java
@@ -99,7 +99,7 @@ public interface Step extends Predicated
      * @return the axis identifier
      * @see org.jaxen.saxpath.Axis
      */
-    public int getAxis();
+    int getAxis();
 
     /**
      * Get an Iterator for the current axis starting in the given contextNode.

--- a/core/src/java/main/org/jaxen/expr/VariableReferenceExpr.java
+++ b/core/src/java/main/org/jaxen/expr/VariableReferenceExpr.java
@@ -64,13 +64,13 @@ public interface VariableReferenceExpr extends Expr
      * 
      * @return the namespace prefix of the variable
      */
-    public String getPrefix();
+    String getPrefix();
     
     /**
      * Returns the local name of the variable. 
      * 
      * @return the local name of the variable
      */
-    public String getVariableName();
+    String getVariableName();
 
 }


### PR DESCRIPTION
Methods in interfaces are public by default. 