### PR TITLE
maven-compiler-plugin 3.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.11.0</version>
         <configuration>
           <debug>true</debug>
           <optimize>true</optimize>


### PR DESCRIPTION
trying to figure out what to do about apparent silent dropping of 1.5 support in JDK 8