### PR TITLE
Fix Unused Export-Package instructions warning in integration-tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -83,6 +83,11 @@
         </executions>
       </plugin>
       
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+
       <!-- Jaxen API Compatibility Checker - detects changes to jaxen's own public API -->
       <plugin>
         <groupId>com.github.siom79.japicmp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -219,28 +219,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>${project.felix.version}</version>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <instructions>
-            <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Version>${project.version}</Bundle-Version>
-            <Export-Package>org.jaxen.*;version=${project.version}</Export-Package>
-          </instructions>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>3.7.1</version>
@@ -382,6 +360,32 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>${project.felix.version}</version>
+          <executions>
+            <execution>
+              <id>bundle-manifest</id>
+              <phase>process-classes</phase>
+              <goals>
+                <goal>manifest</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <instructions>
+              <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+              <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+              <Bundle-Version>${project.version}</Bundle-Version>
+              <Export-Package>org.jaxen.*;version=${project.version}</Export-Package>
+            </instructions>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <reporting>


### PR DESCRIPTION
The issue was caused by the `maven-bundle-plugin` being configured in the parent `pom.xml`'s `<build><plugins>` section, which caused it to run for all modules, including `integration-tests`. Since `integration-tests` doesn't have any packages that match the `org.jaxen.*` pattern defined in the plugin's instructions, it emitted a warning: `[WARNING] Manifest jaxen:jaxen-integration:jar:2.0.2-SNAPSHOT : Unused Export-Package instructions: [org.jaxen.*]`.

The fix involved:
1. Moving the `maven-bundle-plugin` configuration from `<build><plugins>` to `<build><pluginManagement>` in the parent `pom.xml`. This defines the configuration but doesn't activate the plugin by default.
2. Explicitly adding the plugin to the `<build><plugins>` section of `core/pom.xml`. This ensures that the OSGi manifest is still generated for the core library, which is the intended use of the plugin.

This change follows Maven best practices and eliminates the noise in the build output for the integration tests.

---
*PR created automatically by Jules for task [16101487896241458693](https://jules.google.com/task/16101487896241458693) started by @elharo*