### PR TITLE
Fix NoSuchMethodError in Maven site generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.6.2</version>
         <configuration>
           <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>


### PR DESCRIPTION
This change addresses a `NoSuchMethodError` during Maven site generation by downgrading the `maven-project-info-reports-plugin` from `3.7.0` to `3.6.2`. The error was caused by a version mismatch: `3.7.0` requires Doxia 2.0, which is not supported by the project's current `maven-site-plugin` (3.12.1). Downgrading the reports plugin to `3.6.2` restores compatibility with Doxia 1.x. All tests passed and site generation was verified to work correctly with this change.

Fixes #327

---
*PR created automatically by Jules for task [7987287242125582226](https://jules.google.com/task/7987287242125582226) started by @elharo*