### PR TITLE
Reduce Javadoc verbosity in Maven site build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,6 +396,7 @@
         <version>${project.javadoc.version}</version>
         <configuration>
           <doclint>none</doclint>
+          <quiet>true</quiet>
           <bottom>Copyright {inceptionYear}&#x2013;{currentYear} {organizationName}. All rights reserved.</bottom>
           <excludePackageNames>org.jaxen.saxpath.base,org.jaxen.saxpath.helpers,org.jaxen.pattern,org.jaxen.jdom,org.jaxen.xom,org.jaxen.dom4j</excludePackageNames>
           <links>


### PR DESCRIPTION
This change adds `<quiet>true</quiet>` to the `maven-javadoc-plugin` configuration within the `<reporting>` section of the root `pom.xml`. This suppresses informational messages during Javadoc generation when running `mvn site`, making the build output cleaner as requested.

Fixes #324

---
*PR created automatically by Jules for task [15606261974460597280](https://jules.google.com/task/15606261974460597280) started by @elharo*