### PR TITLE
Allow compatible API modifications in japicmp

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -102,7 +102,7 @@
             </goals>
             <configuration>
               <parameter>
-                <breakBuildOnModifications>true</breakBuildOnModifications>
+                <breakBuildOnModifications>false</breakBuildOnModifications>
                 <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
                 <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
                 <onlyModified>true</onlyModified>


### PR DESCRIPTION
The build was failing during site generation because the japicmp-maven-plugin was configured to break the build on *any* modification to the public API, even if compatible. I've updated the configuration to allow compatible modifications while still strictly enforcing binary and source compatibility. This allows the documentation to build even after legitimate API additions.

Fixes #325

---
*PR created automatically by Jules for task [14132107183500575911](https://jules.google.com/task/14132107183500575911) started by @elharo*