### PR TITLE
Suppress maven-bundle-plugin warning in parent project

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,6 +86,9 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
       </plugin>
 
       <!-- Jaxen API Compatibility Checker - detects changes to jaxen's own public API -->

--- a/pom.xml
+++ b/pom.xml
@@ -371,6 +371,7 @@
             </execution>
           </executions>
           <configuration>
+            <skip>true</skip>
             <instructions>
               <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
               <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>


### PR DESCRIPTION
This change addresses the [WARNING] Ignoring project type pom - supportedProjectTypes = [jar, bundle] during the build. By setting <skip>true</skip> in the parent's pluginManagement and <skip>false</skip> in the core module, we ensure that the OSGi manifest is only generated for the relevant JAR artifact, silencing the warning for the parent and integration-tests modules.

Fixes #321

---
*PR created automatically by Jules for task [8884600387311841478](https://jules.google.com/task/8884600387311841478) started by @elharo*