### PR TITLE
Remove extraneous <title> tags from XDoc files

### DIFF
--- a/src/site/xdoc/building.xml
+++ b/src/site/xdoc/building.xml
@@ -7,7 +7,6 @@
   </properties>
 
   <body>
-    <title>Building Jaxen</title>
     
     <section name="Compiling">
       <p>

--- a/src/site/xdoc/extensions.xml
+++ b/src/site/xdoc/extensions.xml
@@ -7,7 +7,6 @@
   </properties>
 
   <body>
-    <title>Writing Jaxen Extension Functions</title>
     
     <section name="What is an extension function?">
       <p>

--- a/src/site/xdoc/faq.xml
+++ b/src/site/xdoc/faq.xml
@@ -3,11 +3,10 @@
 
   <properties>
     <author email="bob.mcwhirter@redhat.com">bob mcwhirter</author>
-    <title>FAQ</title>
+    <title>Frequently Asked Questions</title>
   </properties>
 
   <body>
-    <title>Frequently Asked Questions</title>
     
     <section name="What is jaxen?">
       <p>


### PR DESCRIPTION
The user reported Maven site rendering warnings: "<title> was already defined in <properties>, ignored <title> in <head>." This occurred because several XDoc files in `src/site/xdoc/` had `<title>` tags both in their `<properties>` section and within their `<body>` section.

I identified three files causing these warnings:
- `src/site/xdoc/building.xml`
- `src/site/xdoc/extensions.xml`
- `src/site/xdoc/faq.xml`

I removed the redundant `<title>` tags from the `<body>` of these files. For `faq.xml`, I also updated the title in `<properties>` to "Frequently Asked Questions" for better consistency with the content.

Verified the fix by running `./mvnw site` with compilation and javadoc skipped (to avoid build environment issues with the legacy Java 1.5 target) and confirmed the warnings are no longer present.

Fixes #338

---
*PR created automatically by Jules for task [11538144984781308998](https://jules.google.com/task/11538144984781308998) started by @elharo*