### PR TITLE
Update release notes for version 2.0.2

### DIFF
--- a/src/site/xdoc/releases.xml
+++ b/src/site/xdoc/releases.xml
@@ -12,11 +12,30 @@
 
 
 <p>
-The current version is 2.0.1. This release is completely API compatible with version 2.0.0.
-It fixes several bugs in XPath evaluation and makes builds automated, immutable, and reproducible
+The current version is 2.0.2. This release is completely API compatible with version 2.0.0.
+It fixes two bugs in XPath evaluation: one involving proper handling of NaN and Inf 
+values in the <code>substring</code> function and one correctly ordering
+namespace and attribute nodes in union operations. 
+</p>
+
+      
+      <ul>
+        <li><a href="dist/jaxen-2.0.2-bin.zip">2.0.2  binaries in zip format.</a></li>
+        <li><a href="dist/jaxen-2.0.2-bin.tar.gz">2.0.2 binaries in tar/gz format.</a></li>
+        <li><a href="dist/jaxen-2.0.2-bin.tar.bz2">2.0.2 binaries in bz2 format.</a></li>
+        <li><a href="dist/jaxen-2.0.2-src.zip">2.0.2 sources in zip format.</a></li>
+        <li><a href="dist/jaxen-2.0.2-src.tar.gz">2.0.2 sources in tar/gz format.</a></li>
+        <li><a href="dist/jaxen-2.0.2-src.tar.bz2">2.0.2 sources in bz2 format.</a></li>
+      </ul>
+
+
+<p>
+Version 2.0.1 fixed several bugs in XPath evaluation.
+It also makes builds automated, immutable, and reproducible
 to resist supply chain and MITM attacks.
 </p>
 
+      
 <p>
 2.0.0 now requires Java 1.5 or later, 
 and marks the third party models for XOM, JDOM, and dom4j optional
@@ -44,19 +63,6 @@ With a few small exceptions (e.g. the <code>document()</code> function moved to 
 and the ElectricXML navigator was deleted) 1.1
 is backwards compatible with code written to the 1.0 APIs.
       </p>
-
-      <p>
-      The recommended build is <strong>2.0.0</strong>:
-      </p>
-
-      <ul>
-        <li><a href="dist/jaxen-2.0.0-bin.zip">2.0  binaries in zip format.</a></li>
-        <li><a href="dist/jaxen-2.0.0-bin.tar.gz">2.0 binaries in tar/gz format.</a></li>
-        <li><a href="dist/jaxen-2.0.0-bin.tar.bz2">2.0 binaries in bz2 format.</a></li>
-        <li><a href="dist/jaxen-2.0.0-src.zip">2.0 sources in zip format.</a></li>
-        <li><a href="dist/jaxen-2.0.0-src.tar.gz">2.0 sources in tar/gz format.</a></li>
-        <li><a href="dist/jaxen-2.0.0-src.tar.bz2">2.0 sources in bz2 format.</a></li>
-      </ul>
 
     </section>
 


### PR DESCRIPTION
Updated release notes to reflect version 2.0.2 changes, including bug fixes in XPath evaluation and updated download links.