### PR TITLE
Add deep boolean parser overflow regression tests

### DIFF
--- a/core/src/java/test/org/jaxen/test/XPathReaderTest.java
+++ b/core/src/java/test/org/jaxen/test/XPathReaderTest.java
@@ -53,6 +53,7 @@ import org.jaxen.XPath;
 import org.jaxen.dom.DOMXPath;
 import org.jaxen.saxpath.SAXPathException;
 import org.jaxen.saxpath.base.XPathReader;
+import org.jaxen.saxpath.helpers.DefaultXPathHandler;
 import org.jaxen.saxpath.XPathSyntaxException;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
@@ -123,11 +124,13 @@ public class XPathReaderTest extends TestCase
 
     public void testDeepOrExpressionDoesNotOverflow() throws SAXPathException
     {
+        reader.setXPathHandler( new DefaultXPathHandler() );
         reader.parse( booleanExpression( "or", 20000 ) );
     }
 
     public void testDeepAndExpressionDoesNotOverflow() throws SAXPathException
     {
+        reader.setXPathHandler( new DefaultXPathHandler() );
         reader.parse( booleanExpression( "and", 20000 ) );
     }
 

--- a/core/src/java/test/org/jaxen/test/XPathReaderTest.java
+++ b/core/src/java/test/org/jaxen/test/XPathReaderTest.java
@@ -121,6 +121,16 @@ public class XPathReaderTest extends TestCase
         }
     }
 
+    public void testDeepOrExpressionDoesNotOverflow() throws SAXPathException
+    {
+        reader.parse( booleanExpression( "or", 20000 ) );
+    }
+
+    public void testDeepAndExpressionDoesNotOverflow() throws SAXPathException
+    {
+        reader.parse( booleanExpression( "and", 20000 ) );
+    }
+
     public void testBogusPaths() throws SAXPathException
     {
 
@@ -138,6 +148,20 @@ public class XPathReaderTest extends TestCase
                 assertEquals( bogusPath[1], e.getMessage() );
             }
         }
+    }
+
+    private String booleanExpression(String operator, int count)
+    {
+        StringBuffer result = new StringBuffer( "true()" );
+
+        for ( int i = 1; i < count; i++ )
+        {
+            result.append( ' ' );
+            result.append( operator );
+            result.append( " true()" );
+        }
+
+        return result.toString();
     }
 
     public void testChildrenOfNumber() throws SAXPathException


### PR DESCRIPTION
## Summary

Adds regression coverage for deeply chained boolean `or` and `and` expressions.

When this PR was originally opened, it also changed `XPathReader` to parse chained boolean expressions iteratively instead of with right-recursive calls. Upstream `master` now already contains an iterative boolean parser implementation, so after rebasing this PR is reduced to focused regression tests that lock in the StackOverflowError fix for #434.

The tests parse 20,000-term `or` and `and` expressions using `DefaultXPathHandler`, which keeps the stress focused on parser recursion rather than expression construction callback storage.

## Verification

Ran locally on JDK 21 with a temporary Java 8 compiler-target override, because JDK 21 no longer supports the repository's configured `-source 1.5 -target 1.5` settings:

```shell
.\mvnw.cmd -pl core -Dtest=XPathReaderTest test
```

Result:

```text
Tests run: 36, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

No build configuration changes are included in this PR.