### PR TITLE
Eliminate recursion in getText and toString

### DIFF
--- a/core/src/java/main/org/jaxen/expr/DefaultAdditiveExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultAdditiveExpr.java
@@ -48,10 +48,5 @@ abstract class DefaultAdditiveExpr extends DefaultArithExpr implements AdditiveE
                rhs );
     }
 
-    @Override
-    public String toString()
-    {
-        return "[(" + getClass().getName() + "): " + getLHS() + ", " + getRHS() + "]";
-    }
 }
 

--- a/core/src/java/main/org/jaxen/expr/DefaultAndExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultAndExpr.java
@@ -63,11 +63,6 @@ class DefaultAndExpr extends DefaultLogicalExpr
         return "and";
     }
 
-    @Override
-    public String toString()
-    {
-        return "[(DefaultAndExpr): " + getLHS() + ", " + getRHS() + "]";
-    }
     
     public Object evaluate(Context context) throws JaxenException
     {

--- a/core/src/java/main/org/jaxen/expr/DefaultArithExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultArithExpr.java
@@ -50,9 +50,4 @@ abstract class DefaultArithExpr extends DefaultBinaryExpr
                rhs );
     }
 
-    public String toString()
-    {
-        return "[(DefaultArithExpr): " + getLHS() + ", " + getRHS() + "]";
-    }
-
 }

--- a/core/src/java/main/org/jaxen/expr/DefaultBinaryExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultBinaryExpr.java
@@ -80,6 +80,16 @@ abstract class DefaultBinaryExpr extends DefaultExpr implements BinaryExpr
 
     public String getText()
     {
+        return buildText(false);
+    }
+
+    public String toString()
+    {
+        return buildText(true);
+    }
+
+    private String buildText(boolean useToString)
+    {
         Stack<Expr> stack1 = new Stack<Expr>();
         Stack<Expr> stack2 = new Stack<Expr>();
 
@@ -105,20 +115,22 @@ abstract class DefaultBinaryExpr extends DefaultExpr implements BinaryExpr
                 DefaultBinaryExpr bin = (DefaultBinaryExpr) node;
                 String rhs = resultStack.pop();
                 String lhs = resultStack.pop();
-                resultStack.push("(" + lhs + " " + bin.getOperator() + " " + rhs + ")");
+                if (useToString)
+                {
+                    resultStack.push("[" + bin.getClass().getName() + ": " + lhs + ", " + rhs + "]");
+                }
+                else
+                {
+                    resultStack.push("(" + lhs + " " + bin.getOperator() + " " + rhs + ")");
+                }
             }
             else
             {
-                resultStack.push(node.getText());
+                resultStack.push(useToString ? node.toString() : node.getText());
             }
         }
 
         return resultStack.pop();
-    }
-
-    public String toString()
-    {
-        return "[" + getClass().getName() + ": " + getLHS() + ", " + getRHS() + "]";
     }
 
     protected List<Expr> flattenChain()

--- a/core/src/java/main/org/jaxen/expr/DefaultBinaryExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultBinaryExpr.java
@@ -43,6 +43,7 @@ package org.jaxen.expr;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Stack;
 
 abstract class DefaultBinaryExpr extends DefaultExpr implements BinaryExpr
 {
@@ -79,7 +80,40 @@ abstract class DefaultBinaryExpr extends DefaultExpr implements BinaryExpr
 
     public String getText()
     {
-        return "(" + getLHS().getText() + " " + getOperator() + " " + getRHS().getText() +")";
+        Stack<Expr> stack1 = new Stack<Expr>();
+        Stack<Expr> stack2 = new Stack<Expr>();
+
+        stack1.push(this);
+        while (!stack1.isEmpty())
+        {
+            Expr node = stack1.pop();
+            stack2.push(node);
+            if (node instanceof DefaultBinaryExpr)
+            {
+                DefaultBinaryExpr bin = (DefaultBinaryExpr) node;
+                stack1.push(bin.getLHS());
+                stack1.push(bin.getRHS());
+            }
+        }
+
+        Stack<String> resultStack = new Stack<String>();
+        while (!stack2.isEmpty())
+        {
+            Expr node = stack2.pop();
+            if (node instanceof DefaultBinaryExpr)
+            {
+                DefaultBinaryExpr bin = (DefaultBinaryExpr) node;
+                String rhs = resultStack.pop();
+                String lhs = resultStack.pop();
+                resultStack.push("(" + lhs + " " + bin.getOperator() + " " + rhs + ")");
+            }
+            else
+            {
+                resultStack.push(node.getText());
+            }
+        }
+
+        return resultStack.pop();
     }
 
     public String toString()

--- a/core/src/java/main/org/jaxen/expr/DefaultEqualityExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultEqualityExpr.java
@@ -55,10 +55,6 @@ abstract class DefaultEqualityExpr extends DefaultTruthExpr implements EqualityE
     super( lhs, rhs );
     }
 
-  public String toString()
-    {
-    return "[(DefaultEqualityExpr): " + getLHS() + ", " + getRHS() + "]";
-    }
   
   public Object evaluate( Context context ) throws JaxenException
     {

--- a/core/src/java/main/org/jaxen/expr/DefaultEqualsExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultEqualsExpr.java
@@ -57,11 +57,6 @@ class DefaultEqualsExpr extends DefaultEqualityExpr {
     return "=";
     }
 
-  @Override
-  public String toString()
-  {
-    return "[(DefaultEqualsExpr): " + getLHS() + ", " + getRHS() + "]";
-  }
   
   @Override
   protected boolean evaluateObjectObject( Object lhs, Object rhs )

--- a/core/src/java/main/org/jaxen/expr/DefaultMultiplicativeExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultMultiplicativeExpr.java
@@ -50,9 +50,4 @@ abstract class DefaultMultiplicativeExpr extends DefaultArithExpr
         super( lhs,
                rhs );
     }
-
-    public String toString()
-    {
-        return "[(DefaultMultiplicativeExpr): " + getLHS() + ", " + getRHS() + "]";
-    }
 }

--- a/core/src/java/main/org/jaxen/expr/DefaultNotEqualsExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultNotEqualsExpr.java
@@ -58,11 +58,6 @@ DefaultNotEqualsExpr( Expr lhs, Expr rhs )
     return "!=";
     }
 
-  @Override
-  public String toString()
-    {
-    return "[(DefaultNotEqualsExpr): " + getLHS() + ", " + getRHS() + "]";
-    }
   
   @Override  
   protected boolean evaluateObjectObject( Object lhs, Object rhs )

--- a/core/src/java/main/org/jaxen/expr/DefaultOrExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultOrExpr.java
@@ -65,12 +65,6 @@ class DefaultOrExpr extends DefaultLogicalExpr
         return "or";
     }
 
-    @Override
-    public String toString()
-    {
-        return "[(DefaultOrExpr): " + getLHS() + ", " + getRHS() + "]";
-    }
-
     public Object evaluate(Context context) throws JaxenException
     {
         List<Expr> operands = flattenChain();

--- a/core/src/java/main/org/jaxen/expr/DefaultRelationalExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultRelationalExpr.java
@@ -55,12 +55,6 @@ abstract class DefaultRelationalExpr extends DefaultTruthExpr implements Relatio
     super( lhs, rhs );
     }
   
-  @Override
-  public String toString()
-    {
-    return "[(DefaultRelationalExpr): " + getLHS() + ", " + getRHS() + "]";
-    }
-
   public Object evaluate( Context context ) throws JaxenException
     {
     List<Expr> operands = flattenChain();

--- a/core/src/java/main/org/jaxen/expr/DefaultTruthExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultTruthExpr.java
@@ -52,12 +52,6 @@ abstract class DefaultTruthExpr extends DefaultBinaryExpr
                rhs );
     }
 
-    @Override
-    public String toString()
-    {
-        return "[(DefaultTruthExpr): " + getLHS() + ", " + getRHS() + "]";
-    }
-
     protected boolean bothAreSets(Object lhs,
                                   Object rhs)
     {

--- a/core/src/java/main/org/jaxen/expr/DefaultUnionExpr.java
+++ b/core/src/java/main/org/jaxen/expr/DefaultUnionExpr.java
@@ -67,12 +67,6 @@ class DefaultUnionExpr extends DefaultBinaryExpr implements UnionExpr
         return "|";
     }
 
-    @Override
-    public String toString()
-    {
-        return "[(DefaultUnionExpr): " + getLHS() + ", " + getRHS() + "]";
-    }
-
     public Object evaluate(Context context) throws JaxenException
     {
         List<Expr> operands = flattenChain();

--- a/core/src/java/test/org/jaxen/test/OverflowTest.java
+++ b/core/src/java/test/org/jaxen/test/OverflowTest.java
@@ -111,12 +111,10 @@ public class OverflowTest extends TestCase
     public void testDeepGetText() throws JaxenException
     {
         StringBuilder expression = new StringBuilder(TERMS * 3);
-        for (int i = 1; i <= TERMS; i++)
+        expression.append(1);
+        for (int i = 2; i <= TERMS; i++)
         {
-            if (i > 1)
-            {
-                expression.append('+');
-            }
+            expression.append('+');
             expression.append(i);
         }
 
@@ -131,12 +129,10 @@ public class OverflowTest extends TestCase
     public void testDeepToString() throws JaxenException
     {
         StringBuilder expression = new StringBuilder(TERMS * 3);
-        for (int i = 1; i <= TERMS; i++)
+        expression.append(1);
+        for (int i = 2; i <= TERMS; i++)
         {
-            if (i > 1)
-            {
-                expression.append('+');
-            }
+            expression.append('+');
             expression.append(i);
         }
 

--- a/core/src/java/test/org/jaxen/test/OverflowTest.java
+++ b/core/src/java/test/org/jaxen/test/OverflowTest.java
@@ -108,6 +108,46 @@ public class OverflowTest extends TestCase
         assertEquals(Boolean.FALSE, result);
     }
 
+    public void testDeepGetText() throws JaxenException
+    {
+        StringBuilder expression = new StringBuilder(TERMS * 3);
+        for (int i = 1; i <= TERMS; i++)
+        {
+            if (i > 1)
+            {
+                expression.append('+');
+            }
+            expression.append(i);
+        }
+
+        DOMXPath xpath = new DOMXPath(expression.toString());
+        String text = xpath.getRootExpr().getText();
+
+        assertNotNull(text);
+        assertTrue(text.startsWith("("));
+        assertTrue(text.endsWith(")"));
+    }
+
+    public void testDeepToString() throws JaxenException
+    {
+        StringBuilder expression = new StringBuilder(TERMS * 3);
+        for (int i = 1; i <= TERMS; i++)
+        {
+            if (i > 1)
+            {
+                expression.append('+');
+            }
+            expression.append(i);
+        }
+
+        DOMXPath xpath = new DOMXPath(expression.toString());
+        String text = xpath.getRootExpr().toString();
+
+        assertNotNull(text);
+        assertTrue(text.startsWith("["));
+        assertTrue(text.endsWith("]"));
+    }
+
     public void testManyEqualities() throws JaxenException
     {
         StringBuilder expression = new StringBuilder(TERMS * 4);


### PR DESCRIPTION
Note the most critical, but this is called from a couple of places in expression evaluation when reporting errors so seemed worthwhile. 