### PR TITLE
Fix canFlattenParenthesizedFilterExpr to reject patterns with path operators after predicates

### DIFF
--- a/core/src/java/main/org/jaxen/saxpath/base/XPathReader.java
+++ b/core/src/java/main/org/jaxen/saxpath/base/XPathReader.java
@@ -367,6 +367,15 @@ public class XPathReader implements org.jaxen.saxpath.XPathReader
                 {
                     bracketDepth--;
                 }
+
+                if (bracketDepth == 0 && parenDepth >= 1 && parenDepth < leadingParens)
+                {
+                    int next = LT(i + 1).getTokenType();
+                    if (next != TokenTypes.RIGHT_PAREN && next != TokenTypes.LEFT_BRACKET)
+                    {
+                        return false;
+                    }
+                }
                 continue;
             }
 

--- a/core/src/java/test/org/jaxen/test/XPathReaderTest.java
+++ b/core/src/java/test/org/jaxen/test/XPathReaderTest.java
@@ -70,6 +70,7 @@ public class XPathReaderTest extends TestCase
         "$varname[@a='1']",
         "//attribute::*[.!='crunchy']",
         "'//*[contains(string(text()),\"yada yada\")]'",
+        "((//AST_NODE_TYPE_A)[2]//AST_NODE_TYPE_B)[1]/AST_NODE_TYPE_C"
     };
 
     private String[][] bogusPaths = {


### PR DESCRIPTION
## Problem

PR #462 introduced an optimization to prevent parser stack overflow on deeply nested 
parenthesized filter expressions. However, the `canFlattenParenthesizedFilterExpr()` 
validation is incomplete and incorrectly allows flattening of expressions that contain 
path operators (/ or //) after predicates at intermediate nesting depths.

This causes a parsing failure for valid XPath expressions like:
```
((//AST_NODE_TYPE_A)[2]//AST_NODE_TYPE_B)[1]/AST_NODE_TYPE_C
```
Error: `XPathSyntaxException: ... Expected: )`

## Root Cause

The `canFlattenParenthesizedFilterExpr()` method validates what token comes after a 
closing `)` at intermediate parenthesis depths, but it does not validate what comes 
after a closing `]` (end of predicates). This allows invalid patterns to be marked 
as "flattenable" when they actually contain path operators that break the flattening 
assumption.

The flattening optimization only works when predicates are immediately followed by 
either another `)` or `[`. It fails when a path operator appears after a predicate 
like `[2]//`.

## Solution

Add validation after closing bracket `]` tokens at intermediate parenthesis depths. 
If the next token after a `]` is not `)` or `[`, the pattern cannot be safely flattened, 
so reject it and fall back to the normal recursive parsing path.

## Changes

- Modified `canFlattenParenthesizedFilterExpr()` in `XPathReader.java` to validate 
  tokens after closing brackets `]` at intermediate nesting depths
- Added a test case

## Testing

The failing XPath expression now parses correctly

### Contribution License Acknowledgment

- [x] By checking this box, I agree that my contributions to this project are submitted under the terms of the [Jaxen License](https://github.com/jaxen-xpath/jaxen/blob/master/LICENSE.txt).
